### PR TITLE
Fix LanceDBFTSRetriever not using class level top_k property

### DIFF
--- a/src/lancedb_haystack/fts_retriever.py
+++ b/src/lancedb_haystack/fts_retriever.py
@@ -43,7 +43,7 @@ class LanceDBFTSRetriever:
         self._top_k = top_k
 
     @component.output_types(documents=List[Document])
-    def run(self, query: str, filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = 10):
+    def run(self, query: str, filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None):
         """
         Run the LanceDBFTSRetriever on the given input data.
 


### PR DESCRIPTION
Due to the default value of top_k=10 for the run() method, the class level property of top_k is never used and shadowed by the default value of run()